### PR TITLE
Not passing $unquotedIdentifierFolding to Doctrine\DBAL\Platforms\AbstractPlatform::__construct()

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -3,7 +3,7 @@ name: PHPCS
 on:
   push:
     branches:
-      - 4.2.x
+      - 4.3.x
   pull_request:
 
 jobs:

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -3,7 +3,7 @@ name: PHPStan
 on:
   push:
     branches:
-      - 4.2.x
+      - 4.3.x
   pull_request:
 
 jobs:

--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -1,4 +1,4 @@
-name: Psalm
+name: Rector
 
 on:
   push:
@@ -7,8 +7,8 @@ on:
   pull_request:
 
 jobs:
-  psalm:
-    name: Psalm Static Analysis
+  rector:
+    name: Rector Code Refactoring
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -26,5 +26,5 @@ jobs:
       - name: Install dependencies
         run: composer install --no-progress --no-suggest
 
-      - name: Run Psalm
-        run: vendor/bin/psalm
+      - name: Run Rector
+        run: vendor/bin/rector process --dry-run

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor
 .idea
 composer.lock
+/.phpcs-cache

--- a/composer.json
+++ b/composer.json
@@ -24,9 +24,9 @@
         }
     },
     "require" : {
-        "php": "^8.1",
+        "php": "^8.2",
         "ext-pdo": "*",
-        "doctrine/dbal": "^4.2"
+        "doctrine/dbal": "^4.3"
     },
     "require-dev" : {
         "doctrine/coding-standard": "^12.0.0",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         }
     },
     "require" : {
-        "php": "^8.2",
+        "php": "^8.3",
         "ext-pdo": "*",
         "doctrine/dbal": "^4.3"
     },
@@ -32,9 +32,10 @@
         "doctrine/coding-standard": "^12.0.0",
         "phpstan/phpstan": "1.12.6",
         "phpstan/phpstan-strict-rules": "^1.6",
+        "rector/rector": "^1.2",
         "slevomat/coding-standard": "^8.13.1",
         "squizlabs/php_codesniffer": "^3.6",
-        "vimeo/psalm": "^5.25.0"
+        "vimeo/psalm": "^5.25|^6.15"
     },
     "autoload" : {
         "psr-4" : {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -23,6 +23,7 @@
         <exclude name="SlevomatCodingStandard.ControlStructures.ControlStructureSpacing.IncorrectLinesCountAfterLastControlStructure"/>
         <!-- https://github.com/doctrine/coding-standard/issues/288 -->
         <exclude name="SlevomatCodingStandard.TypeHints.UnionTypeHintFormat.DisallowedShortNullable"/>
+        <exclude name="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFullyQualifiedName"/>
 
         <exclude name="PSR2.Methods.MethodDeclaration.Underscore"/>
         <!-- https://github.com/slevomat/coding-standard/issues/867 -->

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -16,11 +16,6 @@
     </projectFiles>
 
     <issueHandlers>
-        <PossiblyUnusedMethod>
-            <errorLevel type="suppress">
-                <directory name="src/Driver" />
-            </errorLevel>
-        </PossiblyUnusedMethod>
         <InvalidReturnType>
             <errorLevel type="suppress">
                 <file name="src/Driver/Connection.php" />
@@ -46,5 +41,17 @@
                 <file name="src/Driver/Result.php" />
             </errorLevel>
         </LessSpecificReturnStatement>
+        <DeprecatedMethod>
+            <errorLevel type="suppress">
+                <file name="src/Schema/IBMIDB2PDOSchemaManager.php" />
+                <file name="src/Platforms/IBMIDB2PDOPlatform.php" />
+            </errorLevel>
+        </DeprecatedMethod>
+        <DeprecatedClass>
+            <errorLevel type="suppress">
+                <file name="src/Platforms/Keywords/IBMIDB2PDOKeywords.php" />
+                <file name="src/Platforms/IBMIDB2PDOPlatform.php" />
+            </errorLevel>
+        </DeprecatedClass>
     </issueHandlers>
 </psalm>

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Set\ValueObject\LevelSetList;
+
+return RectorConfig::configure()
+    ->withPaths([
+        __DIR__ . '/src',
+    ])
+    ->withSets([
+        LevelSetList::UP_TO_PHP_83,
+    ])
+    ->withPhpSets(php83: true)
+    ->withAttributesSets(all: true)
+    ->withPreparedSets(deadCode: true, codeQuality: true)
+    ->withTypeCoverageLevel(49);

--- a/src/Driver/AbstractIBMIDB2PDODriver.php
+++ b/src/Driver/AbstractIBMIDB2PDODriver.php
@@ -13,11 +13,13 @@ use Doctrine\DBAL\ServerVersionProvider;
 
 abstract class AbstractIBMIDB2PDODriver implements Driver
 {
+    #[\Override]
     public function getDatabasePlatform(ServerVersionProvider $versionProvider): AbstractPlatform
     {
         return new IBMIDB2PDOPlatform();
     }
 
+    #[\Override]
     public function getExceptionConverter(): ExceptionConverterInterface
     {
         return new ExceptionConverter();

--- a/src/Driver/Connection.php
+++ b/src/Driver/Connection.php
@@ -13,19 +13,21 @@ use PDOStatement;
 
 use function assert;
 
-final class Connection implements ConnectionInterface
+final readonly class Connection implements ConnectionInterface
 {
     /** @internal The connection can be only instantiated by its driver. */
-    public function __construct(private readonly PDO $connection)
+    public function __construct(private PDO $connection)
     {
         $connection->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
     }
 
+    #[\Override]
     public function getServerVersion(): string
     {
         return $this->connection->getAttribute(PDO::ATTR_SERVER_VERSION);
     }
 
+    #[\Override]
     public function prepare(string $sql): Statement
     {
         try {
@@ -38,6 +40,7 @@ final class Connection implements ConnectionInterface
         }
     }
 
+    #[\Override]
     public function query(string $sql): Result
     {
         try {
@@ -50,11 +53,13 @@ final class Connection implements ConnectionInterface
         }
     }
 
+    #[\Override]
     public function quote(string $value): string
     {
         return $this->connection->quote($value);
     }
 
+    #[\Override]
     public function exec(string $sql): int|string
     {
         try {
@@ -68,6 +73,7 @@ final class Connection implements ConnectionInterface
         }
     }
 
+    #[\Override]
     public function lastInsertId(): string
     {
         try {
@@ -99,6 +105,7 @@ final class Connection implements ConnectionInterface
         return $value;
     }
 
+    #[\Override]
     public function beginTransaction(): void
     {
         try {
@@ -108,6 +115,7 @@ final class Connection implements ConnectionInterface
         }
     }
 
+    #[\Override]
     public function commit(): void
     {
         try {
@@ -117,6 +125,7 @@ final class Connection implements ConnectionInterface
         }
     }
 
+    #[\Override]
     public function rollBack(): void
     {
         try {
@@ -126,6 +135,7 @@ final class Connection implements ConnectionInterface
         }
     }
 
+    #[\Override]
     public function getNativeConnection(): PDO
     {
         return $this->connection;

--- a/src/Driver/Driver.php
+++ b/src/Driver/Driver.php
@@ -12,13 +12,14 @@ use SensitiveParameter;
 
 use function is_string;
 
-class Driver extends AbstractIBMIDB2PDODriver
+final class Driver extends AbstractIBMIDB2PDODriver
 {
     use PDOConnect;
 
     /**
      * {@inheritDoc}
      */
+    #[\Override]
     public function connect(
         #[SensitiveParameter]
         array $params,

--- a/src/Driver/Result.php
+++ b/src/Driver/Result.php
@@ -11,23 +11,26 @@ use PDOException;
 use PDOStatement;
 use ValueError;
 
-final class Result implements ResultInterface
+final readonly class Result implements ResultInterface
 {
     /** @internal The result can be only instantiated by its driver connection or statement. */
-    public function __construct(private readonly PDOStatement $statement)
+    public function __construct(private PDOStatement $statement)
     {
     }
 
+    #[\Override]
     public function fetchNumeric(): array|false
     {
         return $this->fetch(PDO::FETCH_NUM);
     }
 
+    #[\Override]
     public function fetchAssociative(): array|false
     {
         return $this->fetch(PDO::FETCH_ASSOC);
     }
 
+    #[\Override]
     public function fetchOne(): mixed
     {
         return $this->fetch(PDO::FETCH_COLUMN);
@@ -36,6 +39,7 @@ final class Result implements ResultInterface
     /**
      * {@inheritDoc}
      */
+    #[\Override]
     public function fetchAllNumeric(): array
     {
         return $this->fetchAll(PDO::FETCH_NUM);
@@ -44,6 +48,7 @@ final class Result implements ResultInterface
     /**
      * {@inheritDoc}
      */
+    #[\Override]
     public function fetchAllAssociative(): array
     {
         return $this->fetchAll(PDO::FETCH_ASSOC);
@@ -52,11 +57,13 @@ final class Result implements ResultInterface
     /**
      * {@inheritDoc}
      */
+    #[\Override]
     public function fetchFirstColumn(): array
     {
         return $this->fetchAll(PDO::FETCH_COLUMN);
     }
 
+    #[\Override]
     public function rowCount(): int
     {
         try {
@@ -66,6 +73,7 @@ final class Result implements ResultInterface
         }
     }
 
+    #[\Override]
     public function columnCount(): int
     {
         try {
@@ -92,6 +100,7 @@ final class Result implements ResultInterface
         return $meta['name'];
     }
 
+    #[\Override]
     public function free(): void
     {
         $this->statement->closeCursor();

--- a/src/Driver/Statement.php
+++ b/src/Driver/Statement.php
@@ -11,13 +11,14 @@ use PDO;
 use PDOException;
 use PDOStatement;
 
-final class Statement implements StatementInterface
+final readonly class Statement implements StatementInterface
 {
     /** @internal The statement can be only instantiated by its driver connection. */
-    public function __construct(private readonly PDOStatement $stmt)
+    public function __construct(private PDOStatement $stmt)
     {
     }
 
+    #[\Override]
     public function bindValue(int|string $param, mixed $value, ParameterType $type): void
     {
         $pdoType = $this->convertParamType($type);
@@ -49,6 +50,7 @@ final class Statement implements StatementInterface
         }
     }
 
+    #[\Override]
     public function execute(): Result
     {
         try {

--- a/src/Platforms/IBMIDB2PDOPlatform.php
+++ b/src/Platforms/IBMIDB2PDOPlatform.php
@@ -14,6 +14,7 @@ use Doctrine\DBAL\Platforms\Keywords\KeywordList;
 use Doctrine\DBAL\Schema\ColumnDiff;
 use Doctrine\DBAL\Schema\Identifier;
 use Doctrine\DBAL\Schema\Index;
+use Doctrine\DBAL\Schema\Name\UnquotedIdentifierFolding;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\SQL\Builder\DefaultSelectSQLBuilder;
 use Doctrine\DBAL\SQL\Builder\SelectSQLBuilder;
@@ -29,7 +30,7 @@ use function implode;
 use function sprintf;
 use function str_contains;
 
-class IBMIDB2PDOPlatform extends AbstractPlatform
+final class IBMIDB2PDOPlatform extends AbstractPlatform
 {
     public function __construct()
     {
@@ -39,6 +40,7 @@ class IBMIDB2PDOPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
+    #[\Override]
     public function getBlobTypeDeclarationSQL(array $column): string
     {
         // todo blob(n) with $column['length'];
@@ -48,6 +50,7 @@ class IBMIDB2PDOPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
+    #[\Override]
     public function initializeDoctrineTypeMappings(): void
     {
         $this->doctrineTypeMapping = [
@@ -80,11 +83,13 @@ class IBMIDB2PDOPlatform extends AbstractPlatform
         ];
     }
 
+    #[\Override]
     protected function getBinaryTypeDeclarationSQLSnippet(?int $length): string
     {
         return $this->getCharTypeDeclarationSQLSnippet($length) . ' FOR BIT DATA';
     }
 
+    #[\Override]
     protected function getVarbinaryTypeDeclarationSQLSnippet(?int $length): string
     {
         return $this->getVarcharTypeDeclarationSQLSnippet($length) . ' FOR BIT DATA';
@@ -93,6 +98,7 @@ class IBMIDB2PDOPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
+    #[\Override]
     public function getClobTypeDeclarationSQL(array $column): string
     {
         // todo clob(n) with $column['length'];
@@ -102,6 +108,7 @@ class IBMIDB2PDOPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
+    #[\Override]
     public function getBooleanTypeDeclarationSQL(array $column): string
     {
         return 'SMALLINT';
@@ -110,6 +117,7 @@ class IBMIDB2PDOPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
+    #[\Override]
     public function getIntegerTypeDeclarationSQL(array $column): string
     {
         return 'INTEGER' . $this->_getCommonIntegerTypeDeclarationSQL($column);
@@ -118,6 +126,7 @@ class IBMIDB2PDOPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
+    #[\Override]
     public function getBigIntTypeDeclarationSQL(array $column): string
     {
         return 'BIGINT' . $this->_getCommonIntegerTypeDeclarationSQL($column);
@@ -126,6 +135,7 @@ class IBMIDB2PDOPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
+    #[\Override]
     public function getSmallIntTypeDeclarationSQL(array $column): string
     {
         return 'SMALLINT' . $this->_getCommonIntegerTypeDeclarationSQL($column);
@@ -134,6 +144,7 @@ class IBMIDB2PDOPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
+    #[\Override]
     protected function _getCommonIntegerTypeDeclarationSQL(array $column): string
     {
         $autoinc = '';
@@ -144,16 +155,19 @@ class IBMIDB2PDOPlatform extends AbstractPlatform
         return $autoinc;
     }
 
+    #[\Override]
     public function getBitAndComparisonExpression(string $value1, string $value2): string
     {
         return 'BITAND(' . $value1 . ', ' . $value2 . ')';
     }
 
+    #[\Override]
     public function getBitOrComparisonExpression(string $value1, string $value2): string
     {
         return 'BITOR(' . $value1 . ', ' . $value2 . ')';
     }
 
+    #[\Override]
     protected function getDateArithmeticIntervalExpression(
         string $date,
         string $operator,
@@ -175,6 +189,7 @@ class IBMIDB2PDOPlatform extends AbstractPlatform
         return $date . ' ' . $operator . ' ' . $interval . ' ' . $unit->value;
     }
 
+    #[\Override]
     public function getDateDiffExpression(string $date1, string $date2): string
     {
         return 'DAYS(' . $date1 . ') - DAYS(' . $date2 . ')';
@@ -183,6 +198,7 @@ class IBMIDB2PDOPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
+    #[\Override]
     public function getDateTimeTypeDeclarationSQL(array $column): string
     {
         if (isset($column['version']) && $column['version'] === true) {
@@ -195,6 +211,7 @@ class IBMIDB2PDOPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
+    #[\Override]
     public function getDateTypeDeclarationSQL(array $column): string
     {
         return 'DATE';
@@ -203,11 +220,13 @@ class IBMIDB2PDOPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
+    #[\Override]
     public function getTimeTypeDeclarationSQL(array $column): string
     {
         return 'TIME';
     }
 
+    #[\Override]
     public function getTruncateTableSQL(string $tableName, bool $cascade = false): string
     {
         $tableIdentifier = new Identifier($tableName);
@@ -215,39 +234,46 @@ class IBMIDB2PDOPlatform extends AbstractPlatform
         return 'TRUNCATE ' . $tableIdentifier->getQuotedName($this) . ' IMMEDIATE';
     }
 
+    #[\Override]
     public function getSetTransactionIsolationSQL(TransactionIsolationLevel $level): string
     {
         throw NotSupported::new(__METHOD__);
     }
 
     /** @internal The method should be only used from within the {@see AbstractSchemaManager} class hierarchy. */
+    #[\Override]
     public function getListViewsSQL(string $database): string
     {
         return 'SELECT NAME, TEXT FROM QSYS2.SYSVIEWS';
     }
 
     /** @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy. */
+    #[\Override]
     public function supportsCommentOnStatement(): bool
     {
         return false;
     }
 
+    #[\Override]
     public function getCurrentDateSQL(): string
     {
         return 'CURRENT DATE';
     }
 
+    #[\Override]
     public function getCurrentTimeSQL(): string
     {
         return 'CURRENT TIME';
     }
 
+    #[\Override]
     public function getCurrentTimestampSQL(): string
     {
         return 'CURRENT TIMESTAMP';
     }
 
     /** @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy. */
+    #[\Override]
     public function getIndexDeclarationSQL(Index $index): string
     {
         // Index declaration in statements like CREATE TABLE is not supported.
@@ -257,6 +283,7 @@ class IBMIDB2PDOPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
+    #[\Override]
     protected function _getCreateTableSQL(string $name, array $columns, array $options = []): array
     {
         $indexes = [];
@@ -278,6 +305,7 @@ class IBMIDB2PDOPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
+    #[\Override]
     public function getAlterTableSQL(TableDiff $diff): array
     {
         $sql         = [];
@@ -351,6 +379,7 @@ class IBMIDB2PDOPlatform extends AbstractPlatform
         );
     }
 
+    #[\Override]
     public function getRenameTableSQL(string $oldName, string $newName): string
     {
         return sprintf('RENAME TABLE %s TO %s', $oldName, $newName);
@@ -456,6 +485,7 @@ class IBMIDB2PDOPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
+    #[\Override]
     protected function getPreAlterTableIndexForeignKeySQL(TableDiff $diff): array
     {
         $sql = [];
@@ -491,6 +521,7 @@ class IBMIDB2PDOPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
+    #[\Override]
     protected function getRenameIndexSQL(string $oldIndexName, Index $index, string $tableName): array
     {
         if (str_contains($tableName, '.')) {
@@ -506,36 +537,39 @@ class IBMIDB2PDOPlatform extends AbstractPlatform
      *
      * @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy.
      */
+    #[\Override]
     public function getDefaultValueDeclarationSQL(array $column): string
     {
         if (isset($column['autoincrement']) && $column['autoincrement'] === true) {
             return '';
         }
 
-        if (isset($column['version']) && $column['version'] === true) {
-            if ($column['type'] instanceof DateTimeType) {
-                $column['default'] = '1';
-            }
+        if (isset($column['version']) && $column['version'] === true && $column['type'] instanceof DateTimeType) {
+            $column['default'] = '1';
         }
 
         return parent::getDefaultValueDeclarationSQL($column);
     }
 
+    #[\Override]
     public function getEmptyIdentityInsertSQL(string $quotedTableName, string $quotedIdentifierColumnName): string
     {
         return 'INSERT INTO ' . $quotedTableName . ' (' . $quotedIdentifierColumnName . ') VALUES (DEFAULT)';
     }
 
+    #[\Override]
     public function getCreateTemporaryTableSnippetSQL(): string
     {
         return 'DECLARE GLOBAL TEMPORARY TABLE';
     }
 
+    #[\Override]
     public function getTemporaryTableName(string $tableName): string
     {
         return 'SESSION.' . $tableName;
     }
 
+    #[\Override]
     protected function doModifyLimitQuery(string $query, ?int $limit, int $offset): string
     {
         if ($offset > 0) {
@@ -549,6 +583,7 @@ class IBMIDB2PDOPlatform extends AbstractPlatform
         return $query;
     }
 
+    #[\Override]
     public function getLocateExpression(string $string, string $substring, ?string $start = null): string
     {
         if ($start === null) {
@@ -558,6 +593,7 @@ class IBMIDB2PDOPlatform extends AbstractPlatform
         return sprintf('LOCATE(%s, %s, %s)', $substring, $string, $start);
     }
 
+    #[\Override]
     public function getSubstringExpression(string $string, string $start, ?string $length = null): string
     {
         if ($length === null) {
@@ -567,26 +603,31 @@ class IBMIDB2PDOPlatform extends AbstractPlatform
         return sprintf('SUBSTR(%s, %s, %s)', $string, $start, $length);
     }
 
+    #[\Override]
     public function getLengthExpression(string $string): string
     {
         return 'LENGTH(' . $string . ', CODEUNITS32)';
     }
 
+    #[\Override]
     public function getCurrentDatabaseExpression(): string
     {
         return 'CURRENT_USER';
     }
 
+    #[\Override]
     public function supportsIdentityColumns(): bool
     {
         return true;
     }
 
+    #[\Override]
     public function createSelectSQLBuilder(): SelectSQLBuilder
     {
         return new DefaultSelectSQLBuilder($this, 'WITH RR USE AND KEEP UPDATE LOCKS', null);
     }
 
+    #[\Override]
     public function getDummySelectSQL(string $expression = '1'): string
     {
         return sprintf('SELECT %s FROM sysibm.sysdummy1', $expression);
@@ -599,16 +640,19 @@ class IBMIDB2PDOPlatform extends AbstractPlatform
      *
      * TODO: We have to investigate how to get DB2 up and running with savepoints.
      */
+    #[\Override]
     public function supportsSavepoints(): bool
     {
         return false;
     }
 
+    #[\Override]
     protected function createReservedKeywordsList(): KeywordList
     {
         return new IBMIDB2PDOKeywords();
     }
 
+    #[\Override]
     public function createSchemaManager(Connection $connection): IBMIDB2PDOSchemaManager
     {
         return new IBMIDB2PDOSchemaManager($connection, $this);

--- a/src/Platforms/IBMIDB2PDOPlatform.php
+++ b/src/Platforms/IBMIDB2PDOPlatform.php
@@ -31,6 +31,11 @@ use function str_contains;
 
 class IBMIDB2PDOPlatform extends AbstractPlatform
 {
+    public function __construct()
+    {
+        parent::__construct(UnquotedIdentifierFolding::NONE);
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/src/Platforms/Keywords/IBMIDB2PDOKeywords.php
+++ b/src/Platforms/Keywords/IBMIDB2PDOKeywords.php
@@ -9,11 +9,12 @@ use Doctrine\DBAL\Platforms\Keywords\KeywordList;
 /**
  * DB2 Keywords.
  */
-class IBMIDB2PDOKeywords extends KeywordList
+final class IBMIDB2PDOKeywords extends KeywordList
 {
     /**
      * {@inheritDoc}
      */
+    #[\Override]
     protected function getKeywords(): array
     {
         return [

--- a/src/Schema/IBMIDB2PDOSchemaManager.php
+++ b/src/Schema/IBMIDB2PDOSchemaManager.php
@@ -30,11 +30,12 @@ use const CASE_LOWER;
  *
  * @extends AbstractSchemaManager<IBMIDB2PDOPlatform>
  */
-class IBMIDB2PDOSchemaManager extends AbstractSchemaManager
+final class IBMIDB2PDOSchemaManager extends AbstractSchemaManager
 {
     /**
      * {@inheritDoc}
      */
+    #[\Override]
     protected function _getPortableTableColumnDefinition($tableColumn): Column
     {
         $tableColumn = array_change_key_case($tableColumn, CASE_LOWER);
@@ -46,14 +47,14 @@ class IBMIDB2PDOSchemaManager extends AbstractSchemaManager
         if ($tableColumn['default'] !== null && $tableColumn['default'] !== 'NULL') {
             $default = $tableColumn['default'];
 
-            if (preg_match('/^\'(.*)\'$/s', $default, $matches) === 1) {
+            if (preg_match('/^\'(.*)\'$/s', (string) $default, $matches) === 1) {
                 $default = str_replace("''", "'", $matches[1]);
             }
         }
 
         $type = $this->platform->getDoctrineTypeMapping($tableColumn['typename']);
 
-        switch (strtolower($tableColumn['typename'])) {
+        switch (strtolower((string) $tableColumn['typename'])) {
             case 'character varying':
             case 'datalink':
             case 'national character varying':
@@ -122,6 +123,7 @@ class IBMIDB2PDOSchemaManager extends AbstractSchemaManager
     /**
      * {@inheritDoc}
      */
+    #[\Override]
     protected function _getPortableTableDefinition(array $table): string
     {
         $table = array_change_key_case($table, CASE_LOWER);
@@ -132,19 +134,21 @@ class IBMIDB2PDOSchemaManager extends AbstractSchemaManager
     /**
      * {@inheritDoc}
      */
-    protected function _getPortableTableIndexesList(array $tableIndexes, string $tableName): array
+    #[\Override]
+    protected function _getPortableTableIndexesList(array $rows, string $tableName): array
     {
-        foreach ($tableIndexes as &$tableIndexRow) {
-            $tableIndexRow            = array_change_key_case($tableIndexRow, CASE_LOWER);
+        foreach ($rows as &$tableIndexRow) {
+            $tableIndexRow            = array_change_key_case($tableIndexRow);
             $tableIndexRow['primary'] = (bool) $tableIndexRow['primary'];
         }
 
-        return parent::_getPortableTableIndexesList($tableIndexes, $tableName);
+        return parent::_getPortableTableIndexesList($rows, $tableName);
     }
 
     /**
      * {@inheritDoc}
      */
+    #[\Override]
     protected function _getPortableTableForeignKeyDefinition(array $tableForeignKey): ForeignKeyConstraint
     {
         return new ForeignKeyConstraint(
@@ -159,12 +163,13 @@ class IBMIDB2PDOSchemaManager extends AbstractSchemaManager
     /**
      * {@inheritDoc}
      */
-    protected function _getPortableTableForeignKeysList(array $tableForeignKeys): array
+    #[\Override]
+    protected function _getPortableTableForeignKeysList(array $rows): array
     {
         $foreignKeys = [];
 
-        foreach ($tableForeignKeys as $tableForeignKey) {
-            $tableForeignKey = array_change_key_case($tableForeignKey, CASE_LOWER);
+        foreach ($rows as $tableForeignKey) {
+            $tableForeignKey = array_change_key_case($tableForeignKey);
 
             if (! isset($foreignKeys[$tableForeignKey['index_name']])) {
                 $foreignKeys[$tableForeignKey['index_name']] = [
@@ -189,20 +194,22 @@ class IBMIDB2PDOSchemaManager extends AbstractSchemaManager
     /**
      * {@inheritDoc}
      */
+    #[\Override]
     protected function _getPortableViewDefinition(array $view): View
     {
         $view = array_change_key_case($view, CASE_LOWER);
 
         $sql = '';
-        $pos = strpos($view['text'], ' AS ');
+        $pos = strpos((string) $view['text'], ' AS ');
 
         if ($pos !== false) {
-            $sql = substr($view['text'], $pos + 4);
+            $sql = substr((string) $view['text'], $pos + 4);
         }
 
         return new View($view['name'], $sql);
     }
 
+    #[\Override]
     protected function normalizeName(string $name): string
     {
         $identifier = new Identifier($name);
@@ -210,6 +217,7 @@ class IBMIDB2PDOSchemaManager extends AbstractSchemaManager
         return $identifier->isQuoted() ? $identifier->getName() : strtoupper($name);
     }
 
+    #[\Override]
     protected function selectTableNames(string $databaseName): Result
     {
         $sql = <<<'SQL'
@@ -221,6 +229,7 @@ SQL;
         return $this->connection->executeQuery($sql, [$databaseName]);
     }
 
+    #[\Override]
     protected function selectTableColumns(string $databaseName, ?string $tableName = null): Result
     {
         $sql = 'SELECT';
@@ -229,7 +238,7 @@ SQL;
             $sql .= ' C.TABLE_NAME AS NAME,';
         }
 
-        $sql .= <<<'SQL'
+        $sql .= <<<'SQL_WRAP'
        C.COLUMN_NAME,
        C.DATA_TYPE AS TYPENAME,
        C.CHARACTER_SET_NAME AS CODEPAGE,
@@ -251,7 +260,7 @@ SQL;
               ON D.TABLE_SCHEM = C.TABLE_SCHEMA
                   AND D.TABLE_NAME = C.TABLE_NAME
                   AND D.COLUMN_NAME = C.COLUMN_NAME
-SQL;
+SQL_WRAP;
 
         $conditions = ["T.TABLE_TYPE = 'BASE TABLE'"];
         $params     = [];
@@ -266,6 +275,7 @@ SQL;
         return $this->connection->executeQuery($sql, $params);
     }
 
+    #[\Override]
     protected function selectIndexColumns(string $databaseName, ?string $tableName = null): Result
     {
         $sql1 = 'SELECT';
@@ -363,6 +373,7 @@ SQL;
         return $this->connection->executeQuery($sql, $params);
     }
 
+    #[\Override]
     protected function selectForeignKeyColumns(string $databaseName, ?string $tableName = null): Result
     {
         $sql = 'SELECT';
@@ -420,7 +431,10 @@ SQL;
 
     /**
      * {@inheritDoc}
+     *
+     * @return array<non-empty-string, array{comment: mixed}>
      */
+    #[\Override]
     protected function fetchTableOptionsByTable(string $databaseName, ?string $tableName = null): array
     {
         $sql = 'SELECT NAME, REMARKS';
@@ -439,7 +453,7 @@ SQL;
             $sql .= ' WHERE ' . implode(' AND ', $conditions);
         }
 
-        /** @var array<string,array<string,mixed>> $metadata */
+        /** @var array<non-empty-string, array<string, mixed>> $metadata */
         $metadata = $this->connection->executeQuery($sql, $params)
             ->fetchAllAssociativeIndexed();
 


### PR DESCRIPTION
Upgrading to "doctrine/dbal": "^4.3" triggers the following deprecation warning:

Not passing $unquotedIdentifierFolding to Doctrine\DBAL\Platforms\AbstractPlatform::__construct() is deprecated.

To fix this issue, I created a new 4.3.x branch that:

- Updates "doctrine/dbal" to "^4.3"
- Updates "php" to "^8.3" 
- Adds the missing constructor argument in IBMIDB2PDOPlatform
- Introduce Rector for PHP 8.3 compatibility adjustments 
- Make some classes final
- add #[Override] attribute for overridden methods 
- align PHPStan, Psalm, PHP-CS and introduce Rector github workflows


This ensures compatibility with DBAL 4.3 and removes the deprecation warning.
